### PR TITLE
Fix console enable/install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Prerequisites :
 
 To install this plugin use following commands:
 - Download via composer : composer require icecat/icecat-integration
-- Enable the plugin :  bin/console pimcore:bundle:enable IcecatBundle
-- Install the plugin: bin/console pimcore:bundle:install IcecatBundle
+- Enable the plugin :  bin/console pimcore:bundle:enable IceCatBundle
+- Install the plugin: bin/console pimcore:bundle:install IceCatBundle
 
 **Features in a nutshell**
 - Configure Import from open-icecat.


### PR DESCRIPTION
In linux/docker environment, the console enable/install commands fails due to case sensitivity. 

![image](https://user-images.githubusercontent.com/17026838/138610893-7cf7dbf3-29cd-4378-8fcf-8b89876c3e4f.png)
